### PR TITLE
Upgrade thor gem

### DIFF
--- a/lib/lita/version.rb
+++ b/lib/lita/version.rb
@@ -2,5 +2,5 @@
 
 module Lita
   # The current version of Lita.
-  VERSION = "5.0.2"
+  VERSION = "5.0.3"
 end

--- a/lita.gemspec
+++ b/lita.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rack", "~> 2.2.3"
   spec.add_runtime_dependency "rb-readline", "~> 0.5.5"
   spec.add_runtime_dependency "redis-namespace", "~> 1.8.1"
-  spec.add_runtime_dependency "thor", "~> 1.1.0"
+  spec.add_runtime_dependency "thor", "~> 1.2.0"
 
   spec.add_development_dependency "pry-byebug", "~> 3.9.0"
   spec.add_development_dependency "rack-test", "~> 1.1.0"


### PR DESCRIPTION
https://upbd.atlassian.net/browse/UT-59

Based on this [thread](https://stackoverflow.com/questions/70800753/rails-calling-didyoumeanspell-checkers-mergeerror-name-spell-checker-h) I believe that upgrading the thor gem dependency will get rid of the warning
```ruby
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```